### PR TITLE
🔒 Security: Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,59 @@
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Django
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Node (if applicable)
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# Secrets
+*.key
+*.pem
+*.pfx
+secrets/
+credentials/
+
+# OS
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Adds .gitignore to prevent accidental commits of secrets and sensitive files.

This is a security improvement before making the repo public.