### PR TITLE
Change log filename to 'django_errors.log'

### DIFF
--- a/knowledge_map/knowledge_map/settings/dev.py
+++ b/knowledge_map/knowledge_map/settings/dev.py
@@ -59,7 +59,7 @@ LOGGING = {
     'handlers': {
         'file': {
             'class': 'logging.FileHandler',
-            'filename': os.environ.get('DJANGO_LOG_FILE', 'django_errors.log'),
+            'filename': 'django_errors.log',
             # Falls back to a local file if env var isn't set
         },
     },


### PR DESCRIPTION
Updated the log file configuration to use a static filename.